### PR TITLE
Ci tooling

### DIFF
--- a/.github/workflows/accuracy.yml
+++ b/.github/workflows/accuracy.yml
@@ -7,6 +7,31 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install lint tooling
+        run: pip install -r requirements-dev.txt
+
+      # Same lint the pre-commit hook runs locally, over the whole repo.
+      - name: Ruff lint
+        run: ruff check --output-format=github .
+
+      # Formatter: not enabled yet. Enabling this fails CI until a one-off
+      # `ruff format .` sweep lands, so turn it on in the same PR as that
+      # sweep (and uncomment the ruff-format hook in .pre-commit-config.yaml).
+      # - name: Ruff format check
+      #   run: ruff format --check --diff .
+
   build:
     runs-on: ubuntu-latest
     env:
@@ -24,24 +49,25 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.X']
+        python-version: ['3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pytest_requirements.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r pytest_requirements.txt
+          # Install the package itself so `import abcmb` resolves without a
+          # sys.path hack in the test files.
+          pip install -e . --no-deps
 
       - name: Run tests
-        env:
-          PYTHONPATH: ${{ github.workspace }}/ABCMB
-        run: |
-          cd pytests
-          pytest -s -vv
+        run: pytest -s -vv pytests

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 **/benchmark_scripts/
 **/Module_Tests/
 **/comparison_scripts/
+*.egg-info/
+scratch/
+build/
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Local git hooks. Install once with:
+#     pip install -r requirements-dev.txt
+#     pre-commit install
+#
+# Ruff lint runs on every `git commit`, over the files being committed.
+# CI runs the same lint over the whole repo.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.20
+    hooks:
+      - id: ruff-check    # respects [tool.ruff] excludes/ignores in pyproject.toml
+        args: [--fix]
+
+      # --- Formatter: not enabled yet ---------------------------------------
+      # Enabling `ruff-format` reformats the entire codebase in one commit,
+      # which buries real changes in review noise. To turn it on:
+      #   1. Land a standalone commit that is *only* `ruff format .`
+      #   2. Record that commit's SHA in .git-blame-ignore-revs so `git blame`
+      #      skips it.
+      #   3. Uncomment the hook below and the matching step in
+      #      .github/workflows/accuracy.yml, and drop the `format` cases in
+      #      check.sh.
+      # - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ABCMB<!-- omit from toc -->
 
 Autodifferentiable Boltzmann solver for the CMB (ABCMB) is a Python+JAX package for differentiable computation of the Cosmic Microwave Background.  ABCMB is **complete to linear order** in $\Lambda\rm{CDM}$ cosmology.  It computes the matter and CMB power spectra and includes effects like lensing, massive neutrinos, and a state-of-the-art treatment of the physics of recombination through the companion code [HyRex](https://github.com/TonyZhou729/HyRex).
 
-## Installation
+## User Installation
 ABCMB is pip installable!  Just run
 ```
 pip install ABCMB
@@ -26,6 +26,39 @@ pip install .
 from the code directory. 
 
 Note that both methods of installing will automatically attempt to install JAX for CPU; to install for GPU, refer to the [JAX documentation](https://docs.jax.dev/en/latest/installation.html) for a quick JAX installation guide.
+
+## Developer Installation
+
+If you would like to contribute back to ABCMB, please do the following.
+(Development requires Python 3.11+)
+
+* Fork the repository (see [here](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/fork-a-repo)) and get a local copy on your computer
+* Create a branch for your feature and switch to it (```git switch -c <feature-name>```)
+* Set up the developer environment:
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install -r pytest_requirements.txt   # runtime and test dependencies
+pip install -r requirements-dev.txt      # ruff, pre-commit
+pip install -e . --no-deps               # makes `abcmb` importable from anywhere
+pre-commit install
+```
+
+Optionally, check the setup by running the hooks over the whole repository
+once, so your first commit holds no surprises:
+```
+pre-commit run --all-files
+```
+* Make the changes
+* Verify them with the linter and the test suite, which is what CI runs:
+```
+./check.sh
+```
+* Once finalized, push the changes to a remote branch:
+```
+git push -u origin <feature-name>
+```
+* Draft a pull request against `main` (see [here](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/creating-a-pull-request))
 
 ## Examples
 We have included several pedagogical jupyter notebooks to walk you through how to get started with ABCMB in our [example_notebooks](https://github.com/TonyZhou729/ABCMB/tree/main/example_notebooks) folder.  We suggest you start with [ABCMB_basics](https://github.com/TonyZhou729/ABCMB/blob/main/example_notebooks/ABCMB_basics.ipynb) to get a sense of how to run the code.  If you'd like to add new physics to ABCMB, check out [ABCMB_Fluids](https://github.com/TonyZhou729/ABCMB/blob/main/example_notebooks/ABCMB_Fluids.ipynb).  If you'd like to run ABCMB with the Big Bang Nucleosynthesis (BBN) code [LINX](https://github.com/cgiovanetti/LINX/tree/main) to do BBN+CMB joint analyses, check out [ABCMB_with_LINX](https://github.com/TonyZhou729/ABCMB/blob/main/example_notebooks/ABCMB_with_LINX.ipynb).

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ If you would like to contribute back to ABCMB, please do the following.
 ```
 python -m venv .venv
 source .venv/bin/activate
-pip install -r pytest_requirements.txt   # runtime and test dependencies
-pip install -r requirements-dev.txt      # ruff, pre-commit
-pip install -e . --no-deps               # makes `abcmb` importable from anywhere
+pip install -r pytest_requirements.txt   
+pip install -r requirements-dev.txt      
+pip install -e . --no-deps               
 pre-commit install
 ```
 

--- a/abcmb/ABCMBTools.py
+++ b/abcmb/ABCMBTools.py
@@ -1,13 +1,9 @@
 """
 Script for helper numerical tools
 """
-import jax
-from jax import grad, lax, config, jit, vmap
-from jax.scipy.special import gamma, factorial
-from functools import partial
-import numpy as np
 import jax.numpy as jnp
-import equinox as eqx
+from jax import config, lax, vmap
+from jax.scipy.special import factorial
 
 config.update("jax_enable_x64", True)
 

--- a/abcmb/background.py
+++ b/abcmb/background.py
@@ -1,18 +1,26 @@
-import jax
-from jax import config, vmap, lax
-import numpy as np
-import jax.numpy as jnp
-import equinox as eqx
-from diffrax import diffeqsolve, ODETerm, Kvaerno5, Tsit5, SaveAt, PIDController, ForwardMode
-import optimistix as optx
+import os
 
-from .hyrex.array_with_padding import array_with_padding
-from .hyrex import recomb_functions
-from .hyrex.hyrex import RecombInputs
+import diffrax
+import equinox as eqx
+import jax.numpy as jnp
+import optimistix as optx
+from diffrax import (
+    ForwardMode,
+    Kvaerno5,
+    ODETerm,
+    PIDController,
+    SaveAt,
+    Tsit5,
+    diffeqsolve,
+)
+from jax import config, lax, vmap
+
 from . import ABCMBTools as tools
 from . import constants as cnst
+from .hyrex import recomb_functions
+from .hyrex.array_with_padding import array_with_padding
+from .hyrex.hyrex import RecombInputs
 
-import os
 file_dir = os.path.dirname(__file__)
 config.update("jax_enable_x64", True)
 
@@ -271,9 +279,10 @@ class BackgroundPreRecomb(eqx.Module):
 
         lna_cut = -16.1  # use analytic approx before this
         # Analytic early-time approximation
-        tau_approx = lambda lna: (
-            jnp.exp(lna) / (cnst.H0_over_h / cnst.c_Mpc_over_s) / jnp.sqrt(params["omega_r"])
-        )
+        def tau_approx(lna):
+            return (
+                    jnp.exp(lna) / (cnst.H0_over_h / cnst.c_Mpc_over_s) / jnp.sqrt(params["omega_r"])
+                )
 
         lna_end = self.lna_tau_tab[-1]
 
@@ -701,7 +710,8 @@ class Background(BackgroundPreRecomb):
         Also computes time derivative of optical depth, which is the
         integrand involving the free electron fraction.
         """
-        integrand = lambda lna, y, args: -1./self.tau_c(lna, params)/self.aH(lna, params)
+        def integrand(lna, y, args):
+            return -1./self.tau_c(lna, params)/self.aH(lna, params)
         term = ODETerm(integrand)
         stepsize_controller = PIDController(pcoeff=0.4, icoeff=0.3, dcoeff=0, rtol=1.e-10, atol=1.e-10)
         adjoint=self.adjoint()
@@ -838,7 +848,8 @@ class Background(BackgroundPreRecomb):
         array
             Tabulated baryon optical depth values (units: dimensionless)
         """
-        integrand = lambda lna, y, args: jnp.float64(-1./self.tau_c(lna, params)/self.aH(lna, params)/(self.R_ratio_lna(lna, params)))
+        def integrand(lna, y, args):
+            return jnp.float64(-1./self.tau_c(lna, params)/self.aH(lna, params)/(self.R_ratio_lna(lna, params)))
         term = ODETerm(integrand)
         stepsize_controller = PIDController(pcoeff=0.4, icoeff=0.3, dcoeff=0, rtol=1.e-3, atol=1.e-6)
         adjoint=self.adjoint()
@@ -878,7 +889,8 @@ class Background(BackgroundPreRecomb):
         # initial condition assuming cs**2 = 1/3 at early times
         rs0 = 1./jnp.sqrt(3) / (self.aH( self.lna_tau_tab[0], params ))
 
-        integrand = lambda lna, y, args: 1./jnp.sqrt(3*(1+self.R_ratio_lna(lna, params))) / (self.aH(lna, params))
+        def integrand(lna, y, args):
+            return 1./jnp.sqrt(3*(1+self.R_ratio_lna(lna, params))) / (self.aH(lna, params))
         term = ODETerm(integrand)
         stepsize_controller = PIDController(pcoeff=0.4, icoeff=0.3, dcoeff=0, rtol=1.e-3, atol=1.e-6)
         adjoint=self.adjoint()

--- a/abcmb/constants.py
+++ b/abcmb/constants.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
 from jax import config
+
 config.update("jax_enable_x64", True)
 
 """

--- a/abcmb/main.py
+++ b/abcmb/main.py
@@ -1,27 +1,31 @@
-from jax import jit, config, lax, tree_util
-import jax.numpy as jnp
-from jaxtyping import Array
-import numpy as np
-import equinox as eqx
+import os
+import sys
 
 import diffrax
+import equinox as eqx
 import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import config, lax
+from jaxtyping import Array
 
-import sys
-import os
-file_dir = os.path.dirname(__file__)
-
-from .hyrex import hyrex
-from . import background, perturbations, spectrum, model_specs
+from . import background, model_specs, perturbations, spectrum
 from . import constants as cnst
 from .ABCMBTools import bilinear_interp
-from .background import BackgroundPreRecomb, Background, ReionizationModelFromZ, ReionizationModelFromTau
-
-from .linx.background import BackgroundModel
-from .linx.abundances import AbundanceModel
-from .linx.nuclear import NuclearRates
+from .background import (
+    Background,
+    BackgroundPreRecomb,
+    ReionizationModelFromTau,
+    ReionizationModelFromZ,
+)
+from .hyrex import hyrex
 from .linx import const as linxconst
 from .linx import thermo as linxThermo
+from .linx.abundances import AbundanceModel
+from .linx.background import BackgroundModel
+from .linx.nuclear import NuclearRates
+
+file_dir = os.path.dirname(__file__)
 
 config.update("jax_enable_x64", True)
 
@@ -401,9 +405,9 @@ class Model(eqx.Module):
 
         ### CHECKING INPUT COMPATIBILITY ###
 
-        input_N    = params.get('N_nu_massless') != None
-        input_Neff = params.get('Neff') != None
-        input_T_nu_massless = params.get('T_nu_massless') != None
+        input_N    = params.get('N_nu_massless') is not None
+        input_Neff = params.get('Neff') is not None
+        input_T_nu_massless = params.get('T_nu_massless') is not None
 
         # If the user input both massless neutrino number and Neff, throw an error. Our code treats these as 1-to-1, see paper.
         if input_N and input_Neff:
@@ -480,10 +484,6 @@ class Model(eqx.Module):
             YHe_grid = YHe_all.reshape(n2, n1)
             
             # Neff = params["Neff"] # less extensible option
-            a_bbn = cnst.TCMB_today*1e-6/0.01   # neutrino decoupling is well over by 10 keV, so 
-                                                # compute Neff at a scale factor approximately 
-                                                # corresponding to this temperature
-            lna_bbn = jnp.log(a_bbn)
 
             # Comprehensive Neff, includes all relativsitic species at early times.
             Neff_BBN = params["Neff"]
@@ -527,7 +527,7 @@ class Model(eqx.Module):
                 )
                 params['Neff'] = jax.device_put(Neff_vec[-1],device=jax.devices('gpu')[0])
                 YHe_BBN = jax.device_put(4*abundances[5],device=jax.devices('gpu')[0])
-            except: # no GPU
+            except Exception: # no GPU
                 params['T_nu_massless'] = linxThermo.T_nu(rho_nu_vec[-1]) / linxThermo.T_g(rho_g_vec[-1])
                 params['Neff'] = Neff_vec[-1]
                 YHe_BBN = 4*abundances[5]

--- a/abcmb/model_specs.py
+++ b/abcmb/model_specs.py
@@ -1,8 +1,8 @@
-import numpy as np
 import jax.numpy as jnp
-import equinox as eqx
+import numpy as np
 
 from . import species
+
 
 def load_specs(input_specs):
 

--- a/abcmb/perturbations.py
+++ b/abcmb/perturbations.py
@@ -1,14 +1,13 @@
-import jax
-import jax.numpy as jnp
-import numpy as np
-from jax import vmap, lax
+import os
+
 import diffrax
 import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jax import lax, vmap
 
 from . import constants as cnst
-from . import ABCMBTools as tools
 
-import os
 file_dir = os.path.dirname(__file__)
 jax.config.update("jax_enable_x64", True)
 
@@ -186,7 +185,6 @@ class PerturbationEvolver(eqx.Module):
         """
         BG, params = args
         ### CLASS Initial Conditions ###
-        a = jnp.exp(lna_ini)
         tau_ini = BG.tau(lna_ini)
         
         om = params["om"]

--- a/abcmb/species.py
+++ b/abcmb/species.py
@@ -1,7 +1,8 @@
 #import abc
-from jax import config, lax, vmap
-import jax.numpy as jnp
 import equinox as eqx
+import jax.numpy as jnp
+from jax import config, lax, vmap
+
 from . import constants as cnst
 
 config.update("jax_enable_x64", True)
@@ -1030,7 +1031,6 @@ class MassiveNeutrino(Fluid):
         params = args
         a = jnp.exp(lna)
         T = params['T_nu_massive'] * params['TCMB0'] / a  # (N,)
-        x = params['m_nu_massive'] / T  # (N,)
 
         res = 0.
         for i in range(3):

--- a/abcmb/spectrum.py
+++ b/abcmb/spectrum.py
@@ -1,18 +1,14 @@
-import numpy as np
-import jax.numpy as jnp
+import os
+
 import equinox as eqx
 import jax
-from jax import vmap, jit, config, grad, lax
-from diffrax import diffeqsolve, ODETerm, Dopri5, Kvaerno3, Kvaerno5, Tsit5, SaveAt, PIDController, DiscreteTerminatingEvent
-from jax.scipy.interpolate import RegularGridInterpolator
-from functools import partial
+import jax.numpy as jnp
+import numpy as np
 from interpax import CubicSpline
-from scipy.special import spherical_jn
+from jax import config, grad, lax, vmap
 
 from . import ABCMBTools as tools
-from . import constants as cnst
 
-import os
 file_dir = os.path.dirname(__file__)
 
 config.update("jax_enable_x64", True)
@@ -42,13 +38,16 @@ try:
         xphi2_tab, device=gpus[0])
     phi2_tab = jax.device_put(
         phi2_tab, device=gpus[0])
-except: 
+except Exception:
     pass
 
 # large-x asymptotic expansion of spherical bessel functions
-Q = lambda l, x : jnp.sqrt(x**2-l**2) - l*jnp.pi/2 + l * jnp.arcsin(l/x)
-J = lambda l, x : jnp.sqrt(2/jnp.pi/jnp.sqrt(x**2-l**2)) * jnp.cos(Q(l, x) - jnp.pi/4)
-j = lambda l, x : jnp.sqrt(jnp.pi/2/x) * J(l+1/2, x)
+def Q(l, x):
+    return jnp.sqrt(x**2-l**2) - l*jnp.pi/2 + l * jnp.arcsin(l/x)
+def J(l, x):
+    return jnp.sqrt(2/jnp.pi/jnp.sqrt(x**2-l**2)) * jnp.cos(Q(l, x) - jnp.pi/4)
+def j(l, x):
+    return jnp.sqrt(jnp.pi/2/x) * J(l+1/2, x)
 
 def phi0(i, x):
     """
@@ -409,7 +408,8 @@ class SpectrumSolver(eqx.Module):
         """
 
         coeff = 8.*jnp.pi**2/(ells+0.5)**3
-        chi = lambda lna : BG.tau0 - BG.tau(lna)
+        def chi(lna):
+            return BG.tau0 - BG.tau(lna)
 
         # The previous jnp.nan_to_num(integrand, nan=0.) here masked the
         # forward NaN but left a 0*NaN cotangent in the backward through
@@ -661,7 +661,8 @@ class SpectrumSolver(eqx.Module):
 
         # Perturbations, all (Nlna, Nk) 2D vectors
         # Cubic Spline is necessary here for accuracy. 
-        interp_column = lambda col : CubicSpline(jnp.log10(PT.k), col, check=False)(jnp.log10(k_axis))
+        def interp_column(col):
+            return CubicSpline(jnp.log10(PT.k), col, check=False)(jnp.log10(k_axis))
 
         # Found that this is much much faster than RegularGridInterpolator
         photon_sp = PT.species_perturbations["Photon"]

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Run the linter and the tests in one step (mirrors CI).
+#
+#   ./check.sh          lint + tests
+#   ./check.sh fix      auto-apply fixable lint, then test
+#   ./check.sh test     run the tests only (skip lint)
+#
+# Setup:
+#   pip install -r requirements-dev.txt      # ruff, pre-commit
+#   pip install -r pytest_requirements.txt   # test dependencies
+#   pip install -e . --no-deps               # make `abcmb` importable
+#
+# NOTE: the ruff *formatter* is configured but not switched on — see the
+# commented-out lines below and in .pre-commit-config.yaml.
+#
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Run the linter and the tests (mirrors CI).
+
+Usage: ./check.sh [command]
+
+Commands:
+  (none)   lint + tests
+  fix      auto-apply fixable lint, then run tests
+  test     run the tests only (skip lint)
+  help     show this help
+USAGE
+}
+
+case "${1:-}" in
+    -h|--help|help)
+        usage
+        exit 0
+        ;;
+    test)
+        ;;  # skip ruff, just run tests below
+    fix)
+        # Uncomment once the one-off `ruff format .` sweep has landed:
+        # echo ">> ruff format (applying)"
+        # ruff format .
+        echo ">> ruff check --fix (applying)"
+        ruff check --fix .
+        ;;
+    "")
+        echo ">> ruff check"
+        ruff check .
+        # Uncomment once the one-off `ruff format .` sweep has landed:
+        # echo ">> ruff format --check"
+        # ruff format --check .
+        ;;
+    *)
+        echo "error: unknown command '$1'" >&2
+        usage >&2
+        exit 2
+        ;;
+esac
+
+echo ">> pytest"
+pytest -s -vv pytests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,11 @@ copyright = '2026, Zilu Zhou, Cara Giovanetti, and Hongwan Liu'
 author = 'Zilu Zhou, Cara Giovanetti, and Hongwan Liu'
 
 import sys
+
 sys.path.append('..')
 
 from abcmb.version import __version__
+
 release = __version__
 
 # -- General configuration ---------------------------------------------------
@@ -23,10 +25,11 @@ release = __version__
 # # Make sure Sphinx can import your code
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))  # if your package is in repo root
 
 import re
-import sphinx
+
 from sphinx.util import logging
 
 logger = logging.getLogger(__name__)
@@ -58,8 +61,6 @@ def format_method_summaries(app, what, name, obj, options, lines):
     in_custom_block = False
     in_methods_block = False
     in_prose_section = False
-    just_opened_block = False
-    pending_header = None
 
     i = 0
     while i < len(lines):
@@ -72,8 +73,6 @@ def format_method_summaries(app, what, name, obj, options, lines):
             if re.match(r'^\s*-+\s*$', next_line) and line.strip():
                 # This is a section header with hyphen underlining
                 in_custom_block = True
-                just_opened_block = True
-                pending_header = line
                 
                 # Check if this is a Methods section
                 in_methods_block = bool(re.search(r'Methods:', line, re.IGNORECASE))
@@ -95,7 +94,6 @@ def format_method_summaries(app, what, name, obj, options, lines):
             in_custom_block = True
             in_methods_block = True
             in_prose_section = False
-            just_opened_block = True
 
             # Output the header line with bold formatting
             out.append(f"**{line.strip()}**")
@@ -111,7 +109,6 @@ def format_method_summaries(app, what, name, obj, options, lines):
             in_custom_block = False
             in_methods_block = False
             in_prose_section = False
-            just_opened_block = False
             out.append(line)
             i += 1
             continue
@@ -154,7 +151,6 @@ def skip_equinox_field_attributes(app, what, name, obj, skip, options):
     Skip class attributes that are equinox fields to prevent duplicate documentation.
     These are already documented in the class docstring's Fields section.
     """
-    import inspect
     
     # Only process attributes
     if what not in ('attribute', 'data'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,23 @@
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+# jax==0.8.1 requires Python 3.11+, so target that.
+target-version = "py311"
+# linx/ and hyrex/ are vendored companion codes (LINX, HyRex); leave them to
+# their upstreams rather than linting them to ABCMB's rules.
+# example_notebooks/ are pedagogical; don't rewrite teaching material.
+extend-exclude = ["abcmb/linx", "abcmb/hyrex", "example_notebooks"]
+
+[tool.ruff.lint]
+# Ruff defaults (pyflakes F + pycodestyle E4/E7/E9) plus import sorting (I).
+extend-select = ["I"]
+# `l` is the standard multipole-moment symbol throughout this CMB code
+# (the Output.l attribute, etc.), so don't flag it as an ambiguous name.
+ignore = ["E741"]
+
+[tool.ruff.lint.per-file-ignores]
+# Sphinx conf.py must manipulate sys.path before importing the package for
+# autodoc, so module-level imports legitimately follow other statements.
+"docs/conf.py" = ["E402"]

--- a/pytests/accuracy_test.py
+++ b/pytests/accuracy_test.py
@@ -1,23 +1,11 @@
-from classy import Class
-import os
-os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
-file_dir = os.path.dirname(__file__)
-
-import sys
-sys.path.append(file_dir+'/../')
-# print(os.getcwd())
-import jax
-jax.config.update("jax_enable_x64", True)
-jax.config.update("jax_debug_nans", True)
-from abcmb.main import Model
-import abcmb.spectrum as spectrum
-from abcmb import species
-from scipy.interpolate import interp1d
-import jax.numpy as jnp
 import numpy as np
-import matplotlib.pyplot as plt
 import pytest
-import numpy as np
+from classy import Class
+
+from abcmb import species
+from abcmb.main import Model
+
+# JAX platform, x64, and debug_nans are configured in conftest.py.
 np.seterr(all='raise') 
 
 def test_accuracy_checker(h = 0.6762):
@@ -111,10 +99,8 @@ def test_accuracy_checker(h = 0.6762):
         # ABCMB
 
         output = model(params)
-        ells = output.l
 
         ABC_tt = output.ClTT
-        ABC_te = output.ClTE
         ABC_ee = output.ClEE
 
         # Compare Cltt

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import jax
 
 # Make CI runs consistent

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Developer tooling (linters, git hooks). Install with:
+#     pip install -r requirements-dev.txt
+#
+# Runtime/test dependencies live in setup.cfg and pytest_requirements.txt.
+ruff==0.15.20
+pre-commit

--- a/time_tests.py
+++ b/time_tests.py
@@ -1,12 +1,11 @@
-import sys
-sys.path.append('../')
+import time
 
 import jax
-print(jax.devices())
-jax.config.update("jax_enable_x64", True)
+
 from abcmb.main import Model
 
-import time
+jax.config.update("jax_enable_x64", True)
+print(jax.devices())
 
 specs = {
     "output_Cl" : True,


### PR DESCRIPTION
Previous attempt at #37. The large diff was due to running the ruff formatter (this should be its' own PR)
Modifications:
* Added accuracy tests which run on push to remote (re: github runs the end to end CLASS comparison on CPU)
* Included ruff to perform linting (see [here](https://pypi.org/project/pylint/) for discussion on why to use a linter. Ruff is just a much faster version of PyLint (see [here](https://docs.astral.sh/ruff/) for docs), which is desirable if running the tool on every commit)
* Ran said linter over the codebase (mostly rearranged imports, deleted dead code etc.)
* Added pre-commit to auto run the linter whenever you git commit locally 
* Added Developer Installation section to README
* Added check.sh to allow explicit running of tests/linter (I woul like to later augment to include running a formatter, building documentation etc.)